### PR TITLE
make lexical_has return value work as shown in synopsis

### DIFF
--- a/lib/Sub/Accessor/Small.pm
+++ b/lib/Sub/Accessor/Small.pm
@@ -77,11 +77,14 @@ sub new : method
 sub install_accessors : method
 {
 	my $me = shift;
+	my %collected_coderefs;
 	
 	for my $type (qw( accessor reader writer predicate clearer ))
 	{
 		next unless defined $me->{$type};
-		$me->install_coderef($me->{$type}, $me->$type);
+		my $code = $me->$type;
+		$collected_coderefs{$type} = $code;
+		$me->install_coderef($me->{$type}, $code);
 	}
 	
 	if (defined $me->{handles})
@@ -95,10 +98,10 @@ sub install_accessors : method
 	}
 	
 	my @return =
-		$me->{is} eq 'ro'   ? ($me->{reader}) :
-		$me->{is} eq 'rw'   ? ($me->{accessor}) :
-		$me->{is} eq 'rwp'  ? ($me->{reader}, $me->{writer}) :
-		$me->{is} eq 'lazy' ? ($me->{reader}) :
+		$me->{is} eq 'ro'   ? @collected_coderefs{qw/reader/} :
+		$me->{is} eq 'rw'   ? @collected_coderefs{qw/accessor/} :
+		$me->{is} eq 'rwp'  ? @collected_coderefs{qw/reader writer/} :
+		$me->{is} eq 'lazy' ? @collected_coderefs{qw/reader/} :
 		();
 	wantarray ? @return : $return[0];
 }

--- a/t/02moose.t
+++ b/t/02moose.t
@@ -33,6 +33,12 @@ use Test::Fatal;
 my $trigger;
 my ($ggg, $get_ggg, $set_ggg, $has_ggg, $clear_ggg);
 
+# *_rv is the return value
+my ($aaa, $aaa_rv);  # rw
+my ($get_bbb, $get_bbb_rv);  # ro
+my ($get_ccc, $get_ccc_rv, $set_ccc, $set_ccc_rv);  # rwp
+my ($get_ddd, $get_ddd_rv);  # lazy
+
 {
 	package Goose;
 	
@@ -49,6 +55,28 @@ my ($ggg, $get_ggg, $set_ggg, $has_ggg, $clear_ggg);
 		isa        => Str->plus_coercions(ArrayRef, q[join('', @$_)]),
 		coerce     => 1,
 		trigger    => sub { ++$trigger },
+	);
+	
+	$aaa_rv = lexical_has aaa => (
+		is => 'rw',
+		accessor => \$aaa,
+	);
+	
+	$get_bbb_rv = lexical_has bbb => (
+		is => 'ro',
+		reader => \$get_bbb,
+	);
+	
+	($get_ccc_rv, $set_ccc_rv) = lexical_has ccc => (
+		is => 'rwp',
+		reader => \$get_ccc,
+		writer => \$set_ccc,
+	);
+	
+	$get_ddd_rv = lexical_has ddd => (
+		is => 'lazy',
+		reader => \$get_ddd,
+		default => sub { 42 },
 	);
 }
 
@@ -83,5 +111,11 @@ undef($g2);
 
 is($trigger, 2, 'triggers work');
 ok(!keys %Sub::Accessor::Small::FIELDS, 'no leaks');
+
+is($aaa_rv, $aaa, 'correct accessor returned for is => rw');
+is($get_bbb_rv, $get_bbb, 'correct getter returned for is => ro');
+is($get_ccc_rv, $get_ccc, 'correct getter returned for is => rwp');
+is($set_ccc_rv, $set_ccc, 'correct setter returned for is => rwp');
+is($get_ddd_rv, $get_ddd, 'correct reader returned for is => lazy');
 
 done_testing;

--- a/t/03mouse.t
+++ b/t/03mouse.t
@@ -32,6 +32,12 @@ use Test::Fatal;
 my $trigger;
 my ($ggg, $get_ggg, $set_ggg, $has_ggg, $clear_ggg);
 
+# *_rv is the return value
+my ($aaa, $aaa_rv);  # rw
+my ($get_bbb, $get_bbb_rv);  # ro
+my ($get_ccc, $get_ccc_rv, $set_ccc, $set_ccc_rv);  # rwp
+my ($get_ddd, $get_ddd_rv);  # lazy
+
 {
 	package Grouse;
 	
@@ -48,6 +54,28 @@ my ($ggg, $get_ggg, $set_ggg, $has_ggg, $clear_ggg);
 		isa        => Str->plus_coercions(ArrayRef, q[join('', @$_)]),
 		coerce     => 1,
 		trigger    => sub { ++$trigger },
+	);
+	
+	$aaa_rv = lexical_has aaa => (
+		is => 'rw',
+		accessor => \$aaa,
+	);
+	
+	$get_bbb_rv = lexical_has bbb => (
+		is => 'ro',
+		reader => \$get_bbb,
+	);
+	
+	($get_ccc_rv, $set_ccc_rv) = lexical_has ccc => (
+		is => 'rwp',
+		reader => \$get_ccc,
+		writer => \$set_ccc,
+	);
+	
+	$get_ddd_rv = lexical_has ddd => (
+		is => 'lazy',
+		reader => \$get_ddd,
+		default => sub { 42 },
 	);
 }
 
@@ -82,5 +110,11 @@ undef($g2);
 
 is($trigger, 2, 'triggers work');
 ok(!keys %Sub::Accessor::Small::FIELDS, 'no leaks');
+
+is($aaa_rv, $aaa, 'correct accessor returned for is => rw');
+is($get_bbb_rv, $get_bbb, 'correct getter returned for is => ro');
+is($get_ccc_rv, $get_ccc, 'correct getter returned for is => rwp');
+is($set_ccc_rv, $set_ccc, 'correct setter returned for is => rwp');
+is($get_ddd_rv, $get_ddd, 'correct reader returned for is => lazy');
 
 done_testing;

--- a/t/04moo.t
+++ b/t/04moo.t
@@ -32,6 +32,12 @@ use Test::Fatal;
 my $trigger;
 my ($ggg, $get_ggg, $set_ggg, $has_ggg, $clear_ggg);
 
+# *_rv is the return value
+my ($aaa, $aaa_rv);  # rw
+my ($get_bbb, $get_bbb_rv);  # ro
+my ($get_ccc, $get_ccc_rv, $set_ccc, $set_ccc_rv);  # rwp
+my ($get_ddd, $get_ddd_rv);  # lazy
+
 {
 	package Goo;
 	
@@ -48,6 +54,28 @@ my ($ggg, $get_ggg, $set_ggg, $has_ggg, $clear_ggg);
 		isa        => Str->plus_coercions(ArrayRef, q[join('', @$_)]),
 		coerce     => 1,
 		trigger    => sub { ++$trigger },
+	);
+	
+	$aaa_rv = lexical_has aaa => (
+		is => 'rw',
+		accessor => \$aaa,
+	);
+	
+	$get_bbb_rv = lexical_has bbb => (
+		is => 'ro',
+		reader => \$get_bbb,
+	);
+	
+	($get_ccc_rv, $set_ccc_rv) = lexical_has ccc => (
+		is => 'rwp',
+		reader => \$get_ccc,
+		writer => \$set_ccc,
+	);
+	
+	$get_ddd_rv = lexical_has ddd => (
+		is => 'lazy',
+		reader => \$get_ddd,
+		default => sub { 42 },
 	);
 }
 
@@ -82,5 +110,11 @@ undef($g2);
 
 is($trigger, 2, 'triggers work');
 ok(!keys %Sub::Accessor::Small::FIELDS, 'no leaks');
+
+is($aaa_rv, $aaa, 'correct accessor returned for is => rw');
+is($get_bbb_rv, $get_bbb, 'correct getter returned for is => ro');
+is($get_ccc_rv, $get_ccc, 'correct getter returned for is => rwp');
+is($set_ccc_rv, $set_ccc, 'correct setter returned for is => rwp');
+is($get_ddd_rv, $get_ddd, 'correct reader returned for is => lazy');
 
 done_testing;

--- a/t/05classtiny.t
+++ b/t/05classtiny.t
@@ -32,6 +32,12 @@ use Test::Fatal;
 my $trigger;
 my ($ggg, $get_ggg, $set_ggg, $has_ggg, $clear_ggg);
 
+# *_rv is the return value
+my ($aaa, $aaa_rv);  # rw
+my ($get_bbb, $get_bbb_rv);  # ro
+my ($get_ccc, $get_ccc_rv, $set_ccc, $set_ccc_rv);  # rwp
+my ($get_ddd, $get_ddd_rv);  # lazy
+
 {
 	package Grimy;
 	
@@ -48,6 +54,28 @@ my ($ggg, $get_ggg, $set_ggg, $has_ggg, $clear_ggg);
 		isa        => Str->plus_coercions(ArrayRef, q[join('', @$_)]),
 		coerce     => 1,
 		trigger    => sub { ++$trigger },
+	);
+	
+	$aaa_rv = lexical_has aaa => (
+		is => 'rw',
+		accessor => \$aaa,
+	);
+	
+	$get_bbb_rv = lexical_has bbb => (
+		is => 'ro',
+		reader => \$get_bbb,
+	);
+	
+	($get_ccc_rv, $set_ccc_rv) = lexical_has ccc => (
+		is => 'rwp',
+		reader => \$get_ccc,
+		writer => \$set_ccc,
+	);
+	
+	$get_ddd_rv = lexical_has ddd => (
+		is => 'lazy',
+		reader => \$get_ddd,
+		default => sub { 42 },
 	);
 }
 
@@ -82,5 +110,11 @@ undef($g2);
 
 is($trigger, 2, 'triggers work');
 ok(!keys %Sub::Accessor::Small::FIELDS, 'no leaks');
+
+is($aaa_rv, $aaa, 'correct accessor returned for is => rw');
+is($get_bbb_rv, $get_bbb, 'correct getter returned for is => ro');
+is($get_ccc_rv, $get_ccc, 'correct getter returned for is => rwp');
+is($set_ccc_rv, $set_ccc, 'correct setter returned for is => rwp');
+is($get_ddd_rv, $get_ddd, 'correct reader returned for is => lazy');
 
 done_testing;


### PR DESCRIPTION
The [`Lexical::Accessor` docs](https://metacpan.org/pod/Lexical::Accessor) have this example in the synopsis:

``` perl
my $accessor = lexical_has identifier => (
   is       => 'rw',
   isa      => Int,
   default  => sub { 0 },
);

# later...
say $self->$accessor;
```

To my surprise, it didn't work, because the return value actually was a _reference_ to a coderef. This pull request fixes that by returning proper coderefs, and adds a few basic tests to ensure the proper coderef was returned.

I'm not sure where your distribution would list contributors. Should you merge & release this pull request, please add the information yourself. I am “Lukas Atkinson (cpan:AMON)”.

Anyway, thanks for writing great modules such as this one!
